### PR TITLE
Add id to foods and exercises

### DIFF
--- a/lib/exercise.js
+++ b/lib/exercise.js
@@ -1,29 +1,50 @@
-var Exercise = function(name, calories){
+var Exercise = function(name, calories, id, display){
   this.name = name;
   this.calories = calories;
+  this.id = id;
+  this.display = display;
+}
+
+Exercise.nextId = function(){
+  var currentExercises = all();
+  if(currentExercises.length != 0){
+    return currentExercises[currentExercises.length - 1]['id'] += 1;
+  } else {
+    return 1;
+  }
 }
 
 Exercise.prototype.store = function(){
   var currentExercises = all();
-  currentExercises.push({name: this.name, calories: this.calories});
+  currentExercises.push({id: this.id, name: this.name, calories: this.calories, display: this.display});
   localStorage.setItem('exercises', JSON.stringify(currentExercises));
 }
 
 Exercise.prototype.update = function(attribute, newValue){
   var currentExercises = all();
   for(var i=0; i<currentExercises.length; i++){
-    if(currentExercises[i]['name'] == this.name){
+    if(currentExercises[i]['id'] == this.id){
       currentExercises[i][attribute] = newValue;
     }
   }
   localStorage.setItem('exercises', JSON.stringify(currentExercises));
 }
 
-Exercise.find = function(checkName){
+Exercise.prototype.turnOff = function(){
   var currentExercises = all();
   for(var i=0; i<currentExercises.length; i++){
-    if(currentExercises[i]['name'] == checkName){
-      return new Exercise(currentExercises[i]['name'], currentExercises[i]['calories'])
+    if(currentExercises[i]['id'] == this.id){
+      currentExercises[i]['display'] = 'off';
+    }
+  }
+  localStorage.setItem('exercises', JSON.stringify(currentExercises));
+}
+
+Exercise.find = function(checkId){
+  var currentExercises = all();
+  for(var i=0; i<currentExercises.length; i++){
+    if(currentExercises[i]['id'] == checkId){
+      return new Exercise(currentExercises[i]['name'], currentExercises[i]['calories'], currentExercises[i]['id'], currentExercises[i]['display'])
     }
   }
 }

--- a/lib/exercises_index.js
+++ b/lib/exercises_index.js
@@ -8,8 +8,10 @@ function populateExercises(){
   if(currentExercises !== null){
     var currentExercisesJSON = JSON.parse(currentExercises);
     for (var i = 0; i < currentExercisesJSON.length; i++) {
-      var exerciseItem = new exercise(currentExercisesJSON[i]['name'], currentExercisesJSON[i]['calories']);
-      exerciseTable.appendTo(exerciseItem);
+      var exerciseItem = new exercise(currentExercisesJSON[i]['name'], currentExercisesJSON[i]['calories'], currentExercisesJSON[i]['id'], currentExercisesJSON[i]['display']);
+      if(exerciseItem.display == "on"){
+        exerciseTable.appendTo(exerciseItem);
+      }
     }
   }
 }
@@ -27,15 +29,9 @@ function populateExercises(){
    $('#calorie-error').removeClass('hidden');
  }
 
- function deleteExerciseFromStorage(name){
-   var currentExercises = localStorage.getItem('exercises');
-   var currentExercisesJSON = JSON.parse(currentExercises);
-   for (var i = 0; i < currentExercisesJSON.length; i++) {
-     if(currentExercisesJSON[i]['name'] === name){
-       currentExercisesJSON.splice(i, 1);
-     }
-   }
-   localStorage.setItem('exercises', JSON.stringify(currentExercisesJSON));
+ function removeExerciseFromList(exerciseId){
+   exerciseItem = exercise.find(exerciseId)
+   exerciseItem.turnOff()
  }
 
  function removeErrors(){
@@ -56,7 +52,7 @@ $(document).ready(function(){
       removeErrors()
       caloriesError();
     } else {
-      exerciseItem = new exercise(name, calories)
+      exerciseItem = new exercise(name, calories, exercise.nextId(), 'on');
       exerciseItem.store();
       exerciseTable.appendTo(exerciseItem);
       clearExerciseForm();
@@ -65,8 +61,8 @@ $(document).ready(function(){
   });
 
   $('#exercises-table').on('click', '.delete-button', function(){
-    var name = $(this).parent().siblings('.exercise-name-cell').html();
-    deleteExerciseFromStorage(name);
+    var exerciseId = $(this).parents('tr').data('exercise-id');
+    removeExerciseFromList(exerciseId);
     $(this).parents('tr').remove();
   });
 
@@ -76,6 +72,7 @@ $(document).ready(function(){
 
   $('#exercises-table').on('click', '.exercise-cell', function(e){
     var cell = $(this);
+    var exerciseId = cell.parents('tr').data('exercise-id');
 
     if(e.target != document.activeElement){
       var originalContent = $(this).text();
@@ -90,7 +87,7 @@ $(document).ready(function(){
       if(e.which == 13 || e.type == 'blur') {
         var newContent = $(this).val();
         $(this).parent().text(newContent);
-        exerciseTable.updateCell(cell, originalContent, newContent);
+        exerciseTable.updateCell(cell, exerciseId, originalContent, newContent);
       }
     });
   });

--- a/lib/exercises_table.js
+++ b/lib/exercises_table.js
@@ -3,7 +3,7 @@ var ExerciseTable = function(){}
 
 ExerciseTable.appendTo = function(exerciseItem){
   var deleteButton = '<button class="delete-button"><b>-</b></button>'
-  $('#exercises-table tr:first').after('<tr><td class="exercise-cell exercise-name-cell">' + exerciseItem.name + '</td><td class="exercise-cell exercise-calorie-cell">' + exerciseItem.calories + '</td><td class="delete-cell">' + deleteButton + '</td></tr>');
+  $('#exercises-table tr:first').after('<tr data-exercise-id="' + exerciseItem.id + '"><td class="exercise-cell exercise-name-cell">' + exerciseItem.name + '</td><td class="exercise-cell exercise-calorie-cell">' + exerciseItem.calories + '</td><td class="delete-cell">' + deleteButton + '</td></tr>');
 }
 
 ExerciseTable.appendToDiary = function(exerciseItem){
@@ -47,13 +47,13 @@ ExerciseTable.filterDiary = function(){
   }
 }
 
-ExerciseTable.updateCell = function(cell, originalContent, newContent){
+ExerciseTable.updateCell = function(cell, exerciseId, originalContent, newContent){
   if(cell.hasClass('exercise-name-cell')){
-    var exerciseItem = exercise.find(originalContent);
+    var exerciseItem = exercise.find(exerciseId);
     exerciseItem.update('name', newContent);
   } else if(cell.hasClass('exercise-calorie-cell')){
     var exerciseName = cell.siblings('.exercise-name-cell').html();
-    var exerciseItem = exercise.find(exerciseName);
+    var exerciseItem = exercise.find(exerciseId);
     exerciseItem.update('calories', newContent);
   }
 }

--- a/lib/food.js
+++ b/lib/food.js
@@ -1,11 +1,21 @@
-var Food = function(name, calories){
+var Food = function(name, calories, id){
   this.name = name;
   this.calories = calories;
+  this.id = id;
+}
+
+Food.nextId = function(){
+  var currentFoods = all();
+  if(currentFoods.length != 0){
+    return currentFoods[currentFoods.length - 1]['id'] += 1;
+  } else {
+    return 1;
+  }
 }
 
 Food.prototype.store = function(){
   var currentFoods = all();
-  currentFoods.push({name: this.name, calories: this.calories});
+  currentFoods.push({id: this.id, name: this.name, calories: this.calories});
   localStorage.setItem('foods', JSON.stringify(currentFoods));
 }
 

--- a/lib/food.js
+++ b/lib/food.js
@@ -29,11 +29,11 @@ Food.prototype.update = function(attribute, newValue){
   localStorage.setItem('foods', JSON.stringify(currentFoods));
 }
 
-Food.find = function(checkName){
+Food.find = function(checkId){
   var currentFoods = all();
   for(var i=0; i<currentFoods.length; i++){
-    if(currentFoods[i]['name'] == checkName){
-      return new Food(currentFoods[i]['name'], currentFoods[i]['calories'])
+    if(currentFoods[i]['id'] == checkId){
+      return new Food(currentFoods[i]['name'], currentFoods[i]['calories'], currentFoods[i]['id'])
     }
   }
 }

--- a/lib/food.js
+++ b/lib/food.js
@@ -1,7 +1,8 @@
-var Food = function(name, calories, id){
+var Food = function(name, calories, id, display){
   this.name = name;
   this.calories = calories;
   this.id = id;
+  this.display = display;
 }
 
 Food.nextId = function(){
@@ -15,7 +16,7 @@ Food.nextId = function(){
 
 Food.prototype.store = function(){
   var currentFoods = all();
-  currentFoods.push({id: this.id, name: this.name, calories: this.calories});
+  currentFoods.push({id: this.id, name: this.name, calories: this.calories, display: this.display});
   localStorage.setItem('foods', JSON.stringify(currentFoods));
 }
 
@@ -29,11 +30,21 @@ Food.prototype.update = function(attribute, newValue){
   localStorage.setItem('foods', JSON.stringify(currentFoods));
 }
 
+Food.prototype.turnOff = function(){
+  var currentFoods = all();
+  for(var i=0; i<currentFoods.length; i++){
+    if(currentFoods[i]['id'] == this.id){
+      currentFoods[i]['display'] = 'off';
+    }
+  }
+  localStorage.setItem('foods', JSON.stringify(currentFoods));
+}
+
 Food.find = function(checkId){
   var currentFoods = all();
   for(var i=0; i<currentFoods.length; i++){
     if(currentFoods[i]['id'] == checkId){
-      return new Food(currentFoods[i]['name'], currentFoods[i]['calories'], currentFoods[i]['id'])
+      return new Food(currentFoods[i]['name'], currentFoods[i]['calories'], currentFoods[i]['id'], currentFoods[i]['display'])
     }
   }
 }

--- a/lib/food.js
+++ b/lib/food.js
@@ -22,7 +22,7 @@ Food.prototype.store = function(){
 Food.prototype.update = function(attribute, newValue){
   var currentFoods = all();
   for(var i=0; i<currentFoods.length; i++){
-    if(currentFoods[i]['name'] == this.name){
+    if(currentFoods[i]['id'] == this.id){
       currentFoods[i][attribute] = newValue;
     }
   }

--- a/lib/foods_index.js
+++ b/lib/foods_index.js
@@ -9,7 +9,7 @@ function populateFoods(){
   if(currentFoods !== null){
     var currentFoodsJSON = JSON.parse(currentFoods);
     for (var i = 0; i < currentFoodsJSON.length; i++) {
-      var foodItem = new food(currentFoodsJSON[i]['name'], currentFoodsJSON[i]['calories']);
+      var foodItem = new food(currentFoodsJSON[i]['name'], currentFoodsJSON[i]['calories'], currentFoodsJSON[i]['id']);
       foodsTable.appendTo(foodItem);
     }
   }
@@ -57,7 +57,7 @@ $(document).ready(function(){
       removeErrors()
       caloriesError();
     } else {
-      foodItem = new food(name, calories)
+      foodItem = new food(name, calories, food.nextId());
       foodItem.store();
       foodsTable.appendTo(foodItem);
       clearFoodForm();

--- a/lib/foods_index.js
+++ b/lib/foods_index.js
@@ -77,6 +77,7 @@ $(document).ready(function(){
 
   $('#foods-table').on('click', '.food-cell', function(e){
     var cell = $(this);
+    var foodId = cell.parents('tr').data('food-id');
 
     if(e.target != document.activeElement){
       var originalContent = $(this).text();
@@ -91,7 +92,7 @@ $(document).ready(function(){
       if(e.which == 13 || e.type == 'blur') {
         var newContent = $(this).val();
         $(this).parent().text(newContent);
-        foodsTable.updateCell(cell, originalContent, newContent);
+        foodsTable.updateCell(cell, foodId, originalContent, newContent);
       }
     });
   });

--- a/lib/foods_index.js
+++ b/lib/foods_index.js
@@ -9,8 +9,10 @@ function populateFoods(){
   if(currentFoods !== null){
     var currentFoodsJSON = JSON.parse(currentFoods);
     for (var i = 0; i < currentFoodsJSON.length; i++) {
-      var foodItem = new food(currentFoodsJSON[i]['name'], currentFoodsJSON[i]['calories'], currentFoodsJSON[i]['id']);
-      foodsTable.appendTo(foodItem);
+      var foodItem = new food(currentFoodsJSON[i]['name'], currentFoodsJSON[i]['calories'], currentFoodsJSON[i]['id'], currentFoodsJSON[i]['display']);
+      if(foodItem.display == "on"){
+        foodsTable.appendTo(foodItem);
+      }
     }
   }
 }
@@ -28,15 +30,9 @@ function caloriesError(){
   $('#calorie-error').removeClass('hidden');
 }
 
-function deleteFoodFromStorage(name){
-  var currentFoods = localStorage.getItem('foods');
-  var currentFoodsJSON = JSON.parse(currentFoods);
-  for (var i = 0; i < currentFoodsJSON.length; i++) {
-    if(currentFoodsJSON[i]['name'] === name){
-      currentFoodsJSON.splice(i, 1);
-    }
-  }
-  localStorage.setItem('foods', JSON.stringify(currentFoodsJSON));
+function removeFoodFromList(foodId){
+  foodItem = food.find(foodId)
+  foodItem.turnOff()
 }
 
 function removeErrors(){
@@ -57,7 +53,7 @@ $(document).ready(function(){
       removeErrors()
       caloriesError();
     } else {
-      foodItem = new food(name, calories, food.nextId());
+      foodItem = new food(name, calories, food.nextId(), 'on');
       foodItem.store();
       foodsTable.appendTo(foodItem);
       clearFoodForm();
@@ -66,8 +62,8 @@ $(document).ready(function(){
   });
 
   $('#foods-table').on('click', '.delete-button', function(){
-    var name = $(this).parent().siblings('.food-name-cell').html();
-    deleteFoodFromStorage(name);
+    var foodId = $(this).parents('tr').data('food-id');
+    removeFoodFromList(foodId);
     $(this).parents('tr').remove();
   });
 

--- a/lib/foods_table.js
+++ b/lib/foods_table.js
@@ -5,7 +5,7 @@ var FoodsTable = function(name){
 
 FoodsTable.prototype.appendTo = function(foodItem){
   var deleteButton = '<button class="delete-button"><b>-</b></button>';
-  $('#' + this.name + 's-table tr:first').after('<tr><td class="' + this.name + '-cell ' + this.name + '-name-cell">' + foodItem.name + '</td><td class="' + this.name + '-cell ' + this.name + '-calorie-cell">' + foodItem.calories + '</td><td class="delete-cell">' + deleteButton + '</td></tr>');
+  $('#' + this.name + 's-table tr:first').after('<tr data-food-id="' + foodItem.id + '"><td class="' + this.name + '-cell ' + this.name + '-name-cell">' + foodItem.name + '</td><td class="' + this.name + '-cell ' + this.name + '-calorie-cell">' + foodItem.calories + '</td><td class="delete-cell">' + deleteButton + '</td></tr>');
 }
 
 FoodsTable.prototype.appendToDiary = function(foodItem){

--- a/lib/foods_table.js
+++ b/lib/foods_table.js
@@ -32,13 +32,13 @@ FoodsTable.prototype.filter = function(){
   }
 }
 
-FoodsTable.prototype.updateCell = function(cell, originalContent, newContent){
+FoodsTable.prototype.updateCell = function(cell, foodId, originalContent, newContent){
   if(cell.hasClass('' + this.name + '-name-cell')){
-    var foodItem = food.find(originalContent);
+    var foodItem = food.find(foodId);
     foodItem.update('name', newContent);
   } else if(cell.hasClass('' + this.name + '-calorie-cell')){
     var foodName = cell.siblings('.' + this.name + '-name-cell').html();
-    var foodItem = food.find(foodName);
+    var foodItem = food.find(foodId);
     foodItem.update('calories', newContent)
   }
 }

--- a/test/user_can_add_foods_test.js
+++ b/test/user_can_add_foods_test.js
@@ -58,7 +58,7 @@ test.describe('adding new foods', function(){
     });
 
     driver.executeScript('return window.localStorage["foods"]').then(function(storedFoods){
-      assert.equal(storedFoods, '[{"name":"orange","calories":"500"}]')
+      assert.equal(storedFoods, '[{"id":1,"name":"orange","calories":"500"}]')
     });
 
     driver.findElement({name: 'name'}).getText().then(function(nameText){

--- a/test/user_can_add_foods_test.js
+++ b/test/user_can_add_foods_test.js
@@ -58,7 +58,7 @@ test.describe('adding new foods', function(){
     });
 
     driver.executeScript('return window.localStorage["foods"]').then(function(storedFoods){
-      assert.equal(storedFoods, '[{"id":1,"name":"orange","calories":"500"}]')
+      assert.equal(storedFoods, '[{"id":1,"name":"orange","calories":"500","display":"on"}]')
     });
 
     driver.findElement({name: 'name'}).getText().then(function(nameText){

--- a/test/user_can_delete_exercises.js
+++ b/test/user_can_delete_exercises.js
@@ -46,7 +46,7 @@ test.describe('deleting exercises', function(){
     });
 
     driver.executeScript('return window.localStorage["exercises"]').then(function(storedFoods){
-      assert.equal(storedFoods, '[]')
+      assert.equal(storedFoods, '[{"id":1,"name":"running","calories":"150","display":"off"}]')
     });
   });
 });

--- a/test/user_can_delete_foods_test.js
+++ b/test/user_can_delete_foods_test.js
@@ -44,9 +44,5 @@ test.describe('deleting foods', function(){
         assert.equal(rows.length, 1);
       });
     });
-
-    driver.executeScript('return window.localStorage["foods"]').then(function(storedFoods){
-      assert.equal(storedFoods, '[]')
-    });
   });
 });


### PR DESCRIPTION
Big refactor. Food and Exercise objects not have 'id' and 'display' attributes. 

We find, update and delete by id instead of name.

We don't actually delete anything because it needs to persist to be displayed in diary menus. Instead, we turn display to "off".